### PR TITLE
Asset description hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=6e5a4130f5e7fbd6f195d89d34ed9669686f7635#6e5a4130f5e7fbd6f195d89d34ed9669686f7635"
+source = "git+https://github.com/QED-it/librustzcash?rev=e88964e248c9038e757771b8225c47ac8772abc4#e88964e248c9038e757771b8225c47ac8772abc4"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -798,7 +798,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=6e5a4130f5e7fbd6f195d89d34ed9669686f7635#6e5a4130f5e7fbd6f195d89d34ed9669686f7635"
+source = "git+https://github.com/QED-it/librustzcash?rev=e88964e248c9038e757771b8225c47ac8772abc4#e88964e248c9038e757771b8225c47ac8772abc4"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1703,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "orchard"
 version = "0.8.0"
-source = "git+https://github.com/QED-it/orchard?rev=3dbdbc52c6e2ffeca015ae6eb80ad7f1c870384d#3dbdbc52c6e2ffeca015ae6eb80ad7f1c870384d"
+source = "git+https://github.com/QED-it/orchard?rev=831ca109705a409bc3d3b82e76245e45dd0f0812#831ca109705a409bc3d3b82e76245e45dd0f0812"
 dependencies = [
  "aes",
  "bitvec",
@@ -3243,7 +3243,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.3.2"
-source = "git+https://github.com/QED-it/librustzcash?rev=6e5a4130f5e7fbd6f195d89d34ed9669686f7635#6e5a4130f5e7fbd6f195d89d34ed9669686f7635"
+source = "git+https://github.com/QED-it/librustzcash?rev=e88964e248c9038e757771b8225c47ac8772abc4#e88964e248c9038e757771b8225c47ac8772abc4"
 dependencies = [
  "bech32",
  "bs58",
@@ -3255,7 +3255,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.12.1"
-source = "git+https://github.com/QED-it/librustzcash?rev=6e5a4130f5e7fbd6f195d89d34ed9669686f7635#6e5a4130f5e7fbd6f195d89d34ed9669686f7635"
+source = "git+https://github.com/QED-it/librustzcash?rev=e88964e248c9038e757771b8225c47ac8772abc4#e88964e248c9038e757771b8225c47ac8772abc4"
 dependencies = [
  "base64",
  "bech32",
@@ -3294,7 +3294,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=6e5a4130f5e7fbd6f195d89d34ed9669686f7635#6e5a4130f5e7fbd6f195d89d34ed9669686f7635"
+source = "git+https://github.com/QED-it/librustzcash?rev=e88964e248c9038e757771b8225c47ac8772abc4#e88964e248c9038e757771b8225c47ac8772abc4"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.2.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=6e5a4130f5e7fbd6f195d89d34ed9669686f7635#6e5a4130f5e7fbd6f195d89d34ed9669686f7635"
+source = "git+https://github.com/QED-it/librustzcash?rev=e88964e248c9038e757771b8225c47ac8772abc4#e88964e248c9038e757771b8225c47ac8772abc4"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -3340,7 +3340,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.15.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=6e5a4130f5e7fbd6f195d89d34ed9669686f7635#6e5a4130f5e7fbd6f195d89d34ed9669686f7635"
+source = "git+https://github.com/QED-it/librustzcash?rev=e88964e248c9038e757771b8225c47ac8772abc4#e88964e248c9038e757771b8225c47ac8772abc4"
 dependencies = [
  "aes",
  "bip0039",
@@ -3378,7 +3378,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.15.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=6e5a4130f5e7fbd6f195d89d34ed9669686f7635#6e5a4130f5e7fbd6f195d89d34ed9669686f7635"
+source = "git+https://github.com/QED-it/librustzcash?rev=e88964e248c9038e757771b8225c47ac8772abc4#e88964e248c9038e757771b8225c47ac8772abc4"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -3400,7 +3400,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.1.1"
-source = "git+https://github.com/QED-it/librustzcash?rev=6e5a4130f5e7fbd6f195d89d34ed9669686f7635#6e5a4130f5e7fbd6f195d89d34ed9669686f7635"
+source = "git+https://github.com/QED-it/librustzcash?rev=e88964e248c9038e757771b8225c47ac8772abc4#e88964e248c9038e757771b8225c47ac8772abc4"
 dependencies = [
  "document-features",
  "memuse",
@@ -3417,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_tx_tool"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "abscissa_core",
  "blake2b_simd",
@@ -3546,7 +3546,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.0.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=6e5a4130f5e7fbd6f195d89d34ed9669686f7635#6e5a4130f5e7fbd6f195d89d34ed9669686f7635"
+source = "git+https://github.com/QED-it/librustzcash?rev=e88964e248c9038e757771b8225c47ac8772abc4#e88964e248c9038e757771b8225c47ac8772abc4"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,12 +46,12 @@ abscissa_core = { version = "0.7.0", features = ["testing"] }
 once_cell = "1.2"
 
 [patch.crates-io]
-orchard = { git = "https://github.com/QED-it/orchard", rev = "3dbdbc52c6e2ffeca015ae6eb80ad7f1c870384d" }
+orchard = { git = "https://github.com/QED-it/orchard", rev = "831ca109705a409bc3d3b82e76245e45dd0f0812" }
 sapling-crypto = { git = "https://github.com/QED-it/sapling-crypto", branch = "zsa1" }
 zcash_note_encryption = { git = "https://github.com/QED-it/zcash_note_encryption", branch = "zsa1" }
-zcash_primitives = { git = "https://github.com/QED-it/librustzcash", rev = "6e5a4130f5e7fbd6f195d89d34ed9669686f7635" }
-zcash_protocol = { git = "https://github.com/QED-it/librustzcash", rev = "6e5a4130f5e7fbd6f195d89d34ed9669686f7635" }
-zcash_address = { git = "https://github.com/QED-it/librustzcash", rev = "6e5a4130f5e7fbd6f195d89d34ed9669686f7635" }
-zcash_client_backend = { git = "https://github.com/QED-it/librustzcash", rev = "6e5a4130f5e7fbd6f195d89d34ed9669686f7635" }
-zcash_proofs = { git = "https://github.com/QED-it/librustzcash", rev = "6e5a4130f5e7fbd6f195d89d34ed9669686f7635" }
-zcash_encoding = { git = "https://github.com/QED-it/librustzcash", rev = "6e5a4130f5e7fbd6f195d89d34ed9669686f7635" }
+zcash_primitives = { git = "https://github.com/QED-it/librustzcash", rev = "e88964e248c9038e757771b8225c47ac8772abc4" }
+zcash_protocol = { git = "https://github.com/QED-it/librustzcash", rev = "e88964e248c9038e757771b8225c47ac8772abc4" }
+zcash_address = { git = "https://github.com/QED-it/librustzcash", rev = "e88964e248c9038e757771b8225c47ac8772abc4" }
+zcash_client_backend = { git = "https://github.com/QED-it/librustzcash", rev = "e88964e248c9038e757771b8225c47ac8772abc4" }
+zcash_proofs = { git = "https://github.com/QED-it/librustzcash", rev = "e88964e248c9038e757771b8225c47ac8772abc4" }
+zcash_encoding = { git = "https://github.com/QED-it/librustzcash", rev = "e88964e248c9038e757771b8225c47ac8772abc4" }

--- a/Dockerfile-zebra
+++ b/Dockerfile-zebra
@@ -4,7 +4,7 @@ FROM rust:1.81.0
 RUN apt-get update && apt-get install git build-essential clang -y
 
 # Checkout and build custom branch of the zebra repository
-ARG branch=zsa-integration-demo-ag
+ARG branch=zsa-integration-consensus-burn-in-ag
 ADD https://api.github.com/repos/QED-it/zebra/git/refs/heads/$branch version.json
 RUN git clone -b $branch --single-branch https://github.com/QED-it/zebra.git
 

--- a/Dockerfile-zebra
+++ b/Dockerfile-zebra
@@ -4,7 +4,7 @@ FROM rust:1.81.0
 RUN apt-get update && apt-get install git build-essential clang -y
 
 # Checkout and build custom branch of the zebra repository
-ARG branch=zsa-integration-consensus-burn-in-ag
+ARG branch=zsa-integration-consensus
 ADD https://api.github.com/repos/QED-it/zebra/git/refs/heads/$branch version.json
 RUN git clone -b $branch --single-branch https://github.com/QED-it/zebra.git
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Open a terminal and execute the following commands:
 
 ```bash
 # Build the Zebra Docker image
-docker build -t qedit/zebra-regtest-txv6 .
+docker build -t qedit/zebra-regtest-txv6 -f Dockerfile-zebra .
 
 # Run the Zebra Docker container
 docker run -p 18232:18232 qedit/zebra-regtest-txv6

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.82.0"
 components = [ "clippy", "rustfmt" ]

--- a/src/commands/test_orchard_zsa.rs
+++ b/src/commands/test_orchard_zsa.rs
@@ -38,8 +38,7 @@ impl Runnable for TestOrchardZSACmd {
 
         // --------------------- Issue asset ---------------------
 
-        let issue_tx =
-            create_issue_transaction(issuer, 1000, asset_description, true, &mut wallet);
+        let issue_tx = create_issue_transaction(issuer, 1000, asset_description, true, &mut wallet);
 
         let asset = issue_tx
             .issue_bundle()

--- a/src/commands/test_orchard_zsa.rs
+++ b/src/commands/test_orchard_zsa.rs
@@ -1,6 +1,7 @@
 //! `test` - happy e2e flow that issues, transfers and burns an asset
 
 use abscissa_core::{Command, Runnable};
+use orchard::issuance::compute_asset_desc_hash;
 use orchard::keys::Scope::External;
 
 use crate::commands::test_balances::{check_balances, print_balances, TestBalances};
@@ -28,7 +29,7 @@ impl Runnable for TestOrchardZSACmd {
         let issuer = wallet.address_for_account(0, External);
         let alice = wallet.address_for_account(1, External);
 
-        let asset_description = b"WETH".to_vec();
+        let asset_description = compute_asset_desc_hash(b"WETH").unwrap();
         prepare_test(
             config.chain.v6_activation_height,
             &mut wallet,
@@ -38,7 +39,7 @@ impl Runnable for TestOrchardZSACmd {
         // --------------------- Issue asset ---------------------
 
         let issue_tx =
-            create_issue_transaction(issuer, 1000, asset_description.clone(), true, &mut wallet);
+            create_issue_transaction(issuer, 1000, asset_description, true, &mut wallet);
 
         let asset = issue_tx
             .issue_bundle()

--- a/src/commands/test_orchard_zsa.rs
+++ b/src/commands/test_orchard_zsa.rs
@@ -122,7 +122,7 @@ impl Runnable for TestOrchardZSACmd {
 
         // --------------------- Finalization ---------------------
         // TODO - uncomment when finalization is implemented
-        // let finalization_tx = create_finalization_transaction(asset_description.clone(), &mut user);
+        // let finalization_tx = create_finalization_transaction(asset_desc_hash.clone(), &mut user);
         // mine(
         //     &mut user,
         //     &mut rpc_client,
@@ -130,7 +130,7 @@ impl Runnable for TestOrchardZSACmd {
         //     false,
         // );
         //
-        // let invalid_issue_tx = create_issue_transaction(issuer, 2000, asset_description, &mut user);
+        // let invalid_issue_tx = create_issue_transaction(issuer, 2000, asset_desc_hash, &mut user);
         // mine(
         //     &mut user,
         //     &mut rpc_client,

--- a/src/commands/test_orchard_zsa.rs
+++ b/src/commands/test_orchard_zsa.rs
@@ -29,7 +29,7 @@ impl Runnable for TestOrchardZSACmd {
         let issuer = wallet.address_for_account(0, External);
         let alice = wallet.address_for_account(1, External);
 
-        let asset_description = compute_asset_desc_hash(b"WETH").unwrap();
+        let asset_desc_hash = compute_asset_desc_hash(b"WETH").unwrap();
         prepare_test(
             config.chain.v6_activation_height,
             &mut wallet,
@@ -38,7 +38,7 @@ impl Runnable for TestOrchardZSACmd {
 
         // --------------------- Issue asset ---------------------
 
-        let issue_tx = create_issue_transaction(issuer, 1000, asset_description, true, &mut wallet);
+        let issue_tx = create_issue_transaction(issuer, 1000, asset_desc_hash, true, &mut wallet);
 
         let asset = issue_tx
             .issue_bundle()

--- a/src/components/transactions.rs
+++ b/src/components/transactions.rs
@@ -289,7 +289,8 @@ pub fn create_issue_transaction(
 pub fn create_finalization_transaction(asset_desc: [u8; 32], wallet: &mut User) -> Transaction {
     info!("Finalize asset");
     let mut tx = create_tx(wallet);
-    tx.init_issuance_bundle::<FeeError>(wallet.issuance_key(), asset_desc, None, false).unwrap();
+    tx.init_issuance_bundle::<FeeError>(wallet.issuance_key(), asset_desc, None, false)
+        .unwrap();
     tx.finalize_asset::<FeeError>(&asset_desc).unwrap();
     build_tx(tx)
 }

--- a/src/components/transactions.rs
+++ b/src/components/transactions.rs
@@ -266,7 +266,7 @@ pub fn create_burn_transaction(
 pub fn create_issue_transaction(
     recipient: Address,
     amount: u64,
-    asset_desc: [u8; 32],
+    asset_desc_hash: [u8; 32],
     first_issuance: bool,
     wallet: &mut User,
 ) -> Transaction {
@@ -274,7 +274,7 @@ pub fn create_issue_transaction(
     let mut tx = create_tx(wallet);
     tx.init_issuance_bundle::<FeeError>(
         wallet.issuance_key(),
-        asset_desc,
+        asset_desc_hash,
         Some(IssueInfo {
             recipient,
             value: NoteValue::from_raw(amount),
@@ -286,12 +286,12 @@ pub fn create_issue_transaction(
 }
 
 /// Create a transaction that issues a new asset
-pub fn create_finalization_transaction(asset_desc: [u8; 32], wallet: &mut User) -> Transaction {
+pub fn create_finalization_transaction(asset_desc_hash: [u8; 32], wallet: &mut User) -> Transaction {
     info!("Finalize asset");
     let mut tx = create_tx(wallet);
-    tx.init_issuance_bundle::<FeeError>(wallet.issuance_key(), asset_desc, None, false)
+    tx.init_issuance_bundle::<FeeError>(wallet.issuance_key(), asset_desc_hash, None, false)
         .unwrap();
-    tx.finalize_asset::<FeeError>(&asset_desc).unwrap();
+    tx.finalize_asset::<FeeError>(&asset_desc_hash).unwrap();
     build_tx(tx)
 }
 

--- a/src/components/transactions.rs
+++ b/src/components/transactions.rs
@@ -286,7 +286,10 @@ pub fn create_issue_transaction(
 }
 
 /// Create a transaction that issues a new asset
-pub fn create_finalization_transaction(asset_desc_hash: [u8; 32], wallet: &mut User) -> Transaction {
+pub fn create_finalization_transaction(
+    asset_desc_hash: [u8; 32],
+    wallet: &mut User,
+) -> Transaction {
     info!("Finalize asset");
     let mut tx = create_tx(wallet);
     tx.init_issuance_bundle::<FeeError>(wallet.issuance_key(), asset_desc_hash, None, false)

--- a/src/components/transactions.rs
+++ b/src/components/transactions.rs
@@ -266,7 +266,7 @@ pub fn create_burn_transaction(
 pub fn create_issue_transaction(
     recipient: Address,
     amount: u64,
-    asset_desc: Vec<u8>,
+    asset_desc: [u8; 32],
     first_issuance: bool,
     wallet: &mut User,
 ) -> Transaction {
@@ -286,13 +286,11 @@ pub fn create_issue_transaction(
 }
 
 /// Create a transaction that issues a new asset
-pub fn create_finalization_transaction(asset_desc: Vec<u8>, wallet: &mut User) -> Transaction {
+pub fn create_finalization_transaction(asset_desc: [u8; 32], wallet: &mut User) -> Transaction {
     info!("Finalize asset");
     let mut tx = create_tx(wallet);
-    tx.init_issuance_bundle::<FeeError>(wallet.issuance_key(), asset_desc.clone(), None, false)
-        .unwrap();
-    tx.finalize_asset::<FeeError>(asset_desc.as_slice())
-        .unwrap();
+    tx.init_issuance_bundle::<FeeError>(wallet.issuance_key(), asset_desc, None, false).unwrap();
+    tx.finalize_asset::<FeeError>(&asset_desc).unwrap();
     build_tx(tx)
 }
 


### PR DESCRIPTION
- Use newer versions of Orchard and librustzacsh that implement asset description hash instead of plain description