### PR TITLE
Fix cache usage for zebra in CI

### DIFF
--- a/.github/workflows/zebra-test-ci.yaml
+++ b/.github/workflows/zebra-test-ci.yaml
@@ -26,9 +26,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
-        key: zebra-cache-${{ github.ref }}-${{ github.sha }}
+        key: zebra-cache-${{ runner.os }}-${{ hashFiles('Dockerfile-zebra') }}
         restore-keys: |
-          zebra-cache-${{ github.ref }}
+          zebra-cache-${{ runner.os }}-
           zebra-cache-
       
     - name: Build Zebra Node (Dockerfile-zebra)


### PR DESCRIPTION
Change the cache key used so the cache will be shared between different runs.