### PR TITLE
Move insufficient inputs panic to wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3417,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_tx_tool"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "abscissa_core",
  "blake2b_simd",

--- a/src/components/user.rs
+++ b/src/components/user.rs
@@ -247,6 +247,13 @@ impl User {
                 break;
             }
         }
+        if total_amount_selected < total_amount {
+            panic!(
+                "insufficient inputs: required {} but found {}",
+                total_amount, total_amount_selected
+            );
+        }
+
         selected_notes
     }
 


### PR DESCRIPTION
## Summary
- trigger insufficient inputs panic inside `select_spendable_notes`
- remove the outdated panic call from previous location

## Testing
- `cargo test --quiet`
