### PR TITLE
Change entry point to the compiled executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN ./zcutil/fetch-params.sh
 # Create necessary directories
 RUN mkdir -p /root/.local/share/ZcashParams
 
-# Validate the presence of the config file
+# Validate the presence of the file
 RUN test -f /app/target/release/zcash_tx_tool
 
 # Set default environment variables


### PR DESCRIPTION
When running the tx-tool, because the entry point was running "cargo run" it was by default trying to compile flies again.
This PR changes the entrypoint to the executable that was created when building the docker image.