### PR TITLE
[DRAFT] Temporary: point zebra-test-ci to zsa-integration-demo-with-state (validate QED-it/zebra#89)

### DIFF
--- a/.github/workflows/zebra-test-ci.yaml
+++ b/.github/workflows/zebra-test-ci.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: QED-it/zebra
-          ref: ${{ vars.ZEBRA_BRANCH_TO_TEST || 'zsa-integration-demo' }} # The branch in Zebra we want to test against
+          ref: ${{ vars.ZEBRA_BRANCH_TO_TEST || 'zsa-integration-demo-with-state' }} # The branch in Zebra we want to test against
           path: zebra
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
This is a temporary CI tweak to sanity-check the Zebra changes in QED-it/zebra#89 before merge. It switches the default Zebra branch used by the `zebra-test-ci` workflow from `zsa-integration-demo` to `zsa-integration-demo-with-state`. Draft only — not for merge!