### PR TITLE
Test tx-tool CI against Zebra zsa-integration-state

### DIFF
--- a/.github/workflows/zebra-test-ci.yaml
+++ b/.github/workflows/zebra-test-ci.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: QED-it/zebra
-          ref: ${{ vars.ZEBRA_BRANCH_TO_TEST || 'zsa-integration-demo' }} # The branch in Zebra we want to test against
+          ref: ${{ vars.ZEBRA_BRANCH_TO_TEST || 'zsa-integration-state' }} # The branch in Zebra we want to test against
           path: zebra
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
This draft PR updates the Zebra branch used by `zebra-test-ci.yaml` from `zsa-integration-demo` to `zsa-integration-state`, so we can test `zcash_tx_tool` against the current Zebra `zsa-integration-state` branch.
