### PR TITLE
Updating the printed messages during creation of transfer and burn transactions (main)

### DIFF
--- a/src/components/transactions.rs
+++ b/src/components/transactions.rs
@@ -174,7 +174,7 @@ pub fn create_transfer_transaction(
     rpc_client: &dyn RpcClient,
     wallet: &mut User,
 ) -> Transaction {
-    info!("Transfer {} zatoshi", amount);
+    info!("Transfer {} units", amount);
 
     let ovk = wallet.orchard_ovk();
 
@@ -243,7 +243,7 @@ pub fn create_burn_transaction(
     rpc_client: &dyn RpcClient,
     wallet: &mut User,
 ) -> Transaction {
-    info!("Burn {} zatoshi", amount);
+    info!("Burn {} units", amount);
 
     // Add inputs
     let inputs = wallet.select_spendable_notes(arsonist, amount, asset);


### PR DESCRIPTION
The messages mention zatoshis, which is updated to use units which is more appropriate for the wider class of shielded assets.