### PR TITLE
Add AWS auth to run-tx-tool workflow to fix rate-limitting

### DIFF
--- a/.github/workflows/run-tx-tool.yaml
+++ b/.github/workflows/run-tx-tool.yaml
@@ -23,7 +23,6 @@ on:
     - cron: "*/15 * * * *" # Runs every 15 min
 
 env:
-  AWS_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
   ECR_PUBLIC_AUTH_REGION: us-east-1
   ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY || 'tx-tool' }}
   ECR_PUBLIC_REGISTRY: public.ecr.aws

--- a/.github/workflows/run-tx-tool.yaml
+++ b/.github/workflows/run-tx-tool.yaml
@@ -24,6 +24,7 @@ on:
 
 env:
   AWS_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+  ECR_PUBLIC_AUTH_REGION: us-east-1
   ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY || 'tx-tool' }}
   ECR_PUBLIC_REGISTRY: public.ecr.aws
   ECR_REGISTRY_ALIAS: ${{ vars.ECR_REGISTRY_ALIAS || 'j7v0v6n9' }}
@@ -50,7 +51,7 @@ jobs:
           echo "ZCASH_NODE_PORT=${{ github.event.inputs.zcash_node_port || '443' }}" >> $GITHUB_ENV
           echo "ZCASH_NODE_PROTOCOL=${{ github.event.inputs.zcash_node_protocol || 'https' }}" >> $GITHUB_ENV
           echo "IMAGE_TAG=${{ github.event.inputs.image_tag || 'latest' }}" >> $GITHUB_ENV
-          echo "::set-output name=image_tag::${{ github.event.inputs.image_tag || 'latest' }}"
+          echo "image_tag=${{ github.event.inputs.image_tag || 'latest' }}" >> "$GITHUB_OUTPUT"
 
       - name: Print updated configuration values
         run: |
@@ -63,9 +64,21 @@ jobs:
           echo "ECR_IMAGE=$ECR_PUBLIC_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
           echo "ECR_IMAGE: $ECR_PUBLIC_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG"
 
+      - name: Configure AWS credentials for ECR Public
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.ECR_PUBLIC_AUTH_REGION }}
+
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Pull Docker image from ECR
         run: |
-          docker pull $ECR_IMAGE
+          docker pull "$ECR_IMAGE"
 
       - name: Run Docker container
         run: |
@@ -73,7 +86,7 @@ jobs:
             -e ZCASH_NODE_ADDRESS="$ZCASH_NODE_ADDRESS" \
             -e ZCASH_NODE_PORT="$ZCASH_NODE_PORT" \
             -e ZCASH_NODE_PROTOCOL="$ZCASH_NODE_PROTOCOL" \
-            $ECR_IMAGE
+            "$ECR_IMAGE"
 
       - name: Notify Slack on Success
         if: success() # Runs only if the previous steps succeed


### PR DESCRIPTION
Add AWS authentication to the public ECR repo to fix the rate-limitting issue we were hitting occasionally.