### PR TITLE
Update CI to test Zebra commit

### DIFF
--- a/.github/workflows/zebra-test-ci.yaml
+++ b/.github/workflows/zebra-test-ci.yaml
@@ -1,9 +1,9 @@
 # CI Workflow to test tx-tool against a locally built Zebra node.
-# This workflow clones the zebra repo at a specific branch, builds the Zebra Docker image, and tests tx-tool against it.
+# This workflow clones the zebra repo at a specific commit, builds the Zebra Docker image, and tests tx-tool against it.
 # The workflow ensures tx-tool works correctly by spinning up a Zebra container
 # and running the tx-tool from the current branch against it in a Docker network.
 # Triggers: push to main, pull requests, and manual runs via workflow_dispatch.
-# Please note that the selected Zebra branch should be a branch containing the testnet-single-node-deploy directory with a "dockerfile" and "regtest-config.toml" file in it.
+# Please note that the selected Zebra commit should be a commit containing the testnet-single-node-deploy directory with a "dockerfile" and "regtest-config.toml" file in it.
 
 name: Check tx-tool against Zebra
 

--- a/.github/workflows/zebra-test-ci.yaml
+++ b/.github/workflows/zebra-test-ci.yaml
@@ -35,6 +35,7 @@ jobs:
         with:
           repository: QED-it/zebra
           ref: ${{ vars.ZEBRA_COMMIT_TO_TEST || '63341a59df8b73ed0f50dddacde768a34d8bc245' }} # The commit in Zebra we want to test against
+                                          # The '63341a59df8b73ed0f50dddacde768a34d8bc245' commit is from the 'zsa-integration-demo' branch, from the 03/03/2026
           path: zebra
 
       - name: Set up Docker Buildx

--- a/.github/workflows/zebra-test-ci.yaml
+++ b/.github/workflows/zebra-test-ci.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: QED-it/zebra
-          ref: ${{ vars.ZEBRA_BRANCH_TO_TEST || 'zsa-integration-demo' }} # The branch in Zebra we want to test against
+          ref: ${{ vars.ZEBRA_COMMIT_TO_TEST || '63341a59df8b73ed0f50dddacde768a34d8bc245' }} # The commit in Zebra we want to test against
           path: zebra
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
When testing the tx-tool against the zebra in the CI, pin a specific commit that we want to test against, and not a branch (that can change)