### PR TITLE
Upgrade Zebra to 2b036fd6 + migrate to librustzcash 0.26 / orchard 0.12 (v0.5.0)

### DIFF
--- a/.github/workflows/zebra-test-ci.yaml
+++ b/.github/workflows/zebra-test-ci.yaml
@@ -28,7 +28,7 @@ jobs:
     env:
       # The Zebra commit we test against. Update this to bump the pinned Zebra version.
       # Latest from branch: https://github.com/QED-it/zebra/tree/zsa-integration-demo
-      ZEBRA_COMMIT: ${{ vars.ZEBRA_COMMIT_TO_TEST || 'e9710632479fd449d00097a4817dc3d93dcdf0fe' }}
+      ZEBRA_COMMIT: ${{ vars.ZEBRA_COMMIT_TO_TEST || '2b036fd6d511011e06f632519c7c9d64c2a8ac2d' }}
       # Host-side URL for talking to the Zebra container's JSON-RPC port.
       ZEBRA_RPC_URL: http://127.0.0.1:18232/
 

--- a/.github/workflows/zebra-test-ci.yaml
+++ b/.github/workflows/zebra-test-ci.yaml
@@ -28,7 +28,7 @@ jobs:
     env:
       # The Zebra commit we test against. Update this to bump the pinned Zebra version.
       # Latest from branch: https://github.com/QED-it/zebra/tree/zsa-integration-demo
-      ZEBRA_COMMIT: ${{ vars.ZEBRA_COMMIT_TO_TEST || '63341a59df8b73ed0f50dddacde768a34d8bc245' }}
+      ZEBRA_COMMIT: ${{ vars.ZEBRA_COMMIT_TO_TEST || '7aff71e5b7179489ef8fd03508f89d6e905415dd' }}
       # Host-side URL for talking to the Zebra container's JSON-RPC port.
       ZEBRA_RPC_URL: http://127.0.0.1:18232/
 

--- a/.github/workflows/zebra-test-ci.yaml
+++ b/.github/workflows/zebra-test-ci.yaml
@@ -28,7 +28,7 @@ jobs:
     env:
       # The Zebra commit we test against. Update this to bump the pinned Zebra version.
       # Latest from branch: https://github.com/QED-it/zebra/tree/zsa-integration-demo
-      ZEBRA_COMMIT: ${{ vars.ZEBRA_COMMIT_TO_TEST || '7aff71e5b7179489ef8fd03508f89d6e905415dd' }}
+      ZEBRA_COMMIT: ${{ vars.ZEBRA_COMMIT_TO_TEST || 'e9710632479fd449d00097a4817dc3d93dcdf0fe' }}
       # Host-side URL for talking to the Zebra container's JSON-RPC port.
       ZEBRA_RPC_URL: http://127.0.0.1:18232/
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_tx_tool"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "abscissa_core",
  "bip0039",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/QED-it/librustzcash?rev=acd68d123997ea9788c14244bc3805c6d2e8d68c#acd68d123997ea9788c14244bc3805c6d2e8d68c"
+source = "git+https://github.com/QED-it/librustzcash?rev=0ea737548f7aea6124056df54d55f6c5a35ef914#0ea737548f7aea6124056df54d55f6c5a35ef914"
 dependencies = [
  "blake2b_simd",
  "core2",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/QED-it/librustzcash?rev=acd68d123997ea9788c14244bc3805c6d2e8d68c#acd68d123997ea9788c14244bc3805c6d2e8d68c"
+source = "git+https://github.com/QED-it/librustzcash?rev=0ea737548f7aea6124056df54d55f6c5a35ef914#0ea737548f7aea6124056df54d55f6c5a35ef914"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1079,8 +1079,7 @@ checksum = "47716fe1ae67969c5e0b2ef826f32db8c3be72be325e1aa3c1951d06b5575ec5"
 [[package]]
 name = "halo2_poseidon"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa3da60b81f02f9b33ebc6252d766f843291fb4d2247a07ae73d20b791fc56f"
+source = "git+https://github.com/zcash/halo2?rev=2308caf68c48c02468b66cfc452dad54e355e32f#2308caf68c48c02468b66cfc452dad54e355e32f"
 dependencies = [
  "bitvec",
  "ff",
@@ -1763,8 +1762,8 @@ dependencies = [
 
 [[package]]
 name = "orchard"
-version = "0.11.0"
-source = "git+https://github.com/QED-it/orchard?rev=7ec34c9be7d36ecdce7c3658efe9a78c2863ed97#7ec34c9be7d36ecdce7c3658efe9a78c2863ed97"
+version = "0.12.0"
+source = "git+https://github.com/QED-it/orchard?rev=77d3274cb1f4620e9a1b86477c490fa123dff6bd#77d3274cb1f4620e9a1b86477c490fa123dff6bd"
 dependencies = [
  "aes",
  "bitvec",
@@ -2182,8 +2181,8 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sapling-crypto"
-version = "0.5.0"
-source = "git+https://github.com/QED-it/sapling-crypto?rev=9393f93fe547d1b3738c9f4618c0f8a2fffed29f#9393f93fe547d1b3738c9f4618c0f8a2fffed29f"
+version = "0.6.0"
+source = "git+https://github.com/QED-it/sapling-crypto?rev=59535fb5d34b5c5cf1b20ef18269f5c65228378c#59535fb5d34b5c5cf1b20ef18269f5c65228378c"
 dependencies = [
  "aes",
  "bellman",
@@ -3387,9 +3386,9 @@ dependencies = [
 
 [[package]]
 name = "xdg"
-version = "2.5.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "yoke"
@@ -3416,8 +3415,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.9.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=acd68d123997ea9788c14244bc3805c6d2e8d68c#acd68d123997ea9788c14244bc3805c6d2e8d68c"
+version = "0.10.1"
+source = "git+https://github.com/QED-it/librustzcash?rev=0ea737548f7aea6124056df54d55f6c5a35ef914#0ea737548f7aea6124056df54d55f6c5a35ef914"
 dependencies = [
  "bech32",
  "bs58",
@@ -3430,9 +3429,10 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=acd68d123997ea9788c14244bc3805c6d2e8d68c#acd68d123997ea9788c14244bc3805c6d2e8d68c"
+source = "git+https://github.com/QED-it/librustzcash?rev=0ea737548f7aea6124056df54d55f6c5a35ef914#0ea737548f7aea6124056df54d55f6c5a35ef914"
 dependencies = [
  "core2",
+ "hex",
  "nonempty",
 ]
 
@@ -3450,8 +3450,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.25.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=acd68d123997ea9788c14244bc3805c6d2e8d68c#acd68d123997ea9788c14244bc3805c6d2e8d68c"
+version = "0.26.4"
+source = "git+https://github.com/QED-it/librustzcash?rev=0ea737548f7aea6124056df54d55f6c5a35ef914#0ea737548f7aea6124056df54d55f6c5a35ef914"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -3468,7 +3468,6 @@ dependencies = [
  "hex",
  "incrementalmerkletree",
  "jubjub",
- "lazy_static",
  "memuse",
  "nonempty",
  "orchard",
@@ -3492,8 +3491,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.25.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=acd68d123997ea9788c14244bc3805c6d2e8d68c#acd68d123997ea9788c14244bc3805c6d2e8d68c"
+version = "0.26.1"
+source = "git+https://github.com/QED-it/librustzcash?rev=0ea737548f7aea6124056df54d55f6c5a35ef914#0ea737548f7aea6124056df54d55f6c5a35ef914"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -3503,7 +3502,6 @@ dependencies = [
  "home",
  "jubjub",
  "known-folders",
- "lazy_static",
  "rand_core",
  "redjubjub",
  "sapling-crypto",
@@ -3514,13 +3512,14 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.6.2"
-source = "git+https://github.com/QED-it/librustzcash?rev=acd68d123997ea9788c14244bc3805c6d2e8d68c#acd68d123997ea9788c14244bc3805c6d2e8d68c"
+version = "0.7.2"
+source = "git+https://github.com/QED-it/librustzcash?rev=0ea737548f7aea6124056df54d55f6c5a35ef914#0ea737548f7aea6124056df54d55f6c5a35ef914"
 dependencies = [
  "core2",
  "document-features",
  "hex",
  "memuse",
+ "zcash_encoding",
 ]
 
 [[package]]
@@ -3529,9 +3528,12 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6ef9d04e0434a80b62ad06c5a610557be358ef60a98afa5dbc8ecaf19ad72e7"
 dependencies = [
+ "bip32",
  "bitflags 2.11.0",
  "bounded-vec",
+ "hex",
  "ripemd 0.1.3",
+ "secp256k1",
  "sha1",
  "sha2 0.10.9",
  "thiserror 2.0.18",
@@ -3547,8 +3549,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.5.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=acd68d123997ea9788c14244bc3805c6d2e8d68c#acd68d123997ea9788c14244bc3805c6d2e8d68c"
+version = "0.6.3"
+source = "git+https://github.com/QED-it/librustzcash?rev=0ea737548f7aea6124056df54d55f6c5a35ef914#0ea737548f7aea6124056df54d55f6c5a35ef914"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -3557,6 +3559,7 @@ dependencies = [
  "document-features",
  "getset",
  "hex",
+ "nonempty",
  "ripemd 0.1.3",
  "secp256k1",
  "sha2 0.10.9",
@@ -3599,6 +3602,7 @@ dependencies = [
  "zcash_proofs",
  "zcash_protocol",
  "zcash_transparent",
+ "zip32",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_tx_tool"
 authors = []
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,12 @@ diesel_migrations = "2.2"
 incrementalmerkletree = "0.8.2"
 bridgetree = "0.7.0"
 
-orchard = { version = "0.11.0", features = ["zsa-issuance"] }
-zcash_primitives = { version = "0.25.0", features = ["transparent-inputs", "non-standard-fees", "zsa-issuance", "zip-233"] }
-zcash_protocol = { version = "0.6.2" }
+orchard = { version = "0.12.0", features = ["zsa-issuance"] }
+zcash_primitives = { version = "0.26.1", features = ["transparent-inputs", "non-standard-fees", "zsa-issuance", "zip-233"] }
+zcash_protocol = { version = "0.7.2" }
 zcash_encoding = "0.3.0"
-zcash_proofs = "0.25.0"
+zcash_proofs = "0.26.1"
+zip32 = "0.2"
 
 serde_json = "1.0.149"
 hex = { version = "0.4.3", features = ["serde"] }
@@ -33,7 +34,7 @@ bip0039 = "0.12.0"
 nonempty = "0.11.0"
 
 # - Transparent inputs
-zcash_transparent = { version = "0.5.0", features = ["transparent-inputs"] }
+zcash_transparent = { version = "0.6.3", features = ["transparent-inputs"] }
 ripemd = { version = "0.1" }
 sha2 = "0.10"
 secp256k1 = { version = "0.29.1" }
@@ -50,15 +51,16 @@ once_cell = "1.21"
 non_local_definitions = "allow"
 
 [patch.crates-io]
-orchard = { git = "https://github.com/QED-it/orchard", rev = "7ec34c9be7d36ecdce7c3658efe9a78c2863ed97" }
-sapling-crypto = { git = "https://github.com/QED-it/sapling-crypto", rev = "9393f93fe547d1b3738c9f4618c0f8a2fffed29f" }
+orchard = { git = "https://github.com/QED-it/orchard", rev = "77d3274cb1f4620e9a1b86477c490fa123dff6bd" }
+sapling-crypto = { git = "https://github.com/QED-it/sapling-crypto", rev = "59535fb5d34b5c5cf1b20ef18269f5c65228378c" }
 zcash_note_encryption = { git = "https://github.com/zcash/zcash_note_encryption", rev = "9f7e93d42cef839d02b9d75918117941d453f8cb" }
-zcash_primitives = { git = "https://github.com/QED-it/librustzcash", rev = "acd68d123997ea9788c14244bc3805c6d2e8d68c" }
-zcash_protocol = { git = "https://github.com/QED-it/librustzcash", rev = "acd68d123997ea9788c14244bc3805c6d2e8d68c" }
-zcash_address = { git = "https://github.com/QED-it/librustzcash", rev = "acd68d123997ea9788c14244bc3805c6d2e8d68c" }
-zcash_proofs = { git = "https://github.com/QED-it/librustzcash", rev = "acd68d123997ea9788c14244bc3805c6d2e8d68c" }
-zcash_encoding = { git = "https://github.com/QED-it/librustzcash", rev = "acd68d123997ea9788c14244bc3805c6d2e8d68c" }
-zcash_transparent = { git = "https://github.com/QED-it/librustzcash", rev = "acd68d123997ea9788c14244bc3805c6d2e8d68c" }
+zcash_primitives = { git = "https://github.com/QED-it/librustzcash", rev = "0ea737548f7aea6124056df54d55f6c5a35ef914" }
+zcash_protocol = { git = "https://github.com/QED-it/librustzcash", rev = "0ea737548f7aea6124056df54d55f6c5a35ef914" }
+zcash_address = { git = "https://github.com/QED-it/librustzcash", rev = "0ea737548f7aea6124056df54d55f6c5a35ef914" }
+zcash_proofs = { git = "https://github.com/QED-it/librustzcash", rev = "0ea737548f7aea6124056df54d55f6c5a35ef914" }
+zcash_encoding = { git = "https://github.com/QED-it/librustzcash", rev = "0ea737548f7aea6124056df54d55f6c5a35ef914" }
+zcash_transparent = { git = "https://github.com/QED-it/librustzcash", rev = "0ea737548f7aea6124056df54d55f6c5a35ef914" }
 sinsemilla = { git = "https://github.com/zcash/sinsemilla", rev = "aabb707e862bc3d7b803c77d14e5a771bcee3e8c" }
 halo2_proofs = { git = "https://github.com/zcash/halo2", rev = "2308caf68c48c02468b66cfc452dad54e355e32f" }
+halo2_poseidon = { git = "https://github.com/zcash/halo2", rev = "2308caf68c48c02468b66cfc452dad54e355e32f" }
 zcash_spec = { git = "https://github.com/QED-it/zcash_spec", rev = "d5e84264d2ad0646b587a837f4e2424ca64d3a05" }

--- a/src/commands/test_orchard.rs
+++ b/src/commands/test_orchard.rs
@@ -128,8 +128,6 @@ fn prepare_test(
     rpc_client: &mut ReqwestRpcClient,
 ) -> TxId {
     sync_from_height(c, target_height, wallet, rpc_client);
-    let activate = wallet.last_block_height().is_none();
-    let (_, coinbase_txid) =
-        mine_empty_blocks(100, rpc_client, activate).expect("block mined successfully"); // coinbase maturity = 100
+    let (_, coinbase_txid) = mine_empty_blocks(100, rpc_client).expect("block mined successfully"); // coinbase maturity = 100
     coinbase_txid
 }

--- a/src/components/miner.rs
+++ b/src/components/miner.rs
@@ -11,7 +11,7 @@ use bip0039::Mnemonic;
 use ripemd::{Digest, Ripemd160};
 use secp256k1::{Secp256k1, SecretKey};
 use sha2::Sha256;
-use zcash_primitives::zip32::AccountId;
+use zip32::AccountId;
 use zcash_protocol::consensus::REGTEST_NETWORK;
 use zcash_transparent::address::TransparentAddress;
 use zcash_transparent::builder::TransparentSigningSet;

--- a/src/components/rpc_client/mock.rs
+++ b/src/components/rpc_client/mock.rs
@@ -8,7 +8,7 @@ use std::error::Error;
 use std::io;
 use std::io::ErrorKind;
 use zcash_primitives::block::BlockHash;
-use zcash_primitives::consensus::{BlockHeight, BranchId};
+use zcash_protocol::consensus::{BlockHeight, BranchId};
 use zcash_primitives::transaction::{Transaction, TxId};
 
 pub struct MockZcashNode {

--- a/src/components/rpc_client/reqwest.rs
+++ b/src/components/rpc_client/reqwest.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::error::Error;
 use zcash_primitives::block::BlockHash;
-use zcash_primitives::consensus::{BlockHeight, BranchId};
+use zcash_protocol::consensus::{BlockHeight, BranchId};
 use zcash_primitives::transaction::{Transaction, TxId};
 
 pub struct ReqwestRpcClient {

--- a/src/components/transactions.rs
+++ b/src/components/transactions.rs
@@ -37,8 +37,7 @@ pub fn mine(
     rpc_client: &mut dyn RpcClient,
     txs: Vec<Transaction>,
 ) -> Result<(), Box<dyn Error>> {
-    let activate = wallet.last_block_height().is_none();
-    mine_block(rpc_client, txs, activate)?;
+    mine_block(rpc_client, txs)?;
     sync(conn, wallet, rpc_client);
     Ok(())
 }
@@ -46,12 +45,11 @@ pub fn mine(
 pub fn mine_block(
     rpc_client: &mut dyn RpcClient,
     txs: Vec<Transaction>,
-    activate: bool,
 ) -> Result<(u32, TxId), Box<dyn Error>> {
     let block_template = rpc_client.get_block_template()?;
     let block_height = block_template.height;
 
-    let block_proposal = template_into_proposal(block_template, txs, activate);
+    let block_proposal = template_into_proposal(block_template, txs);
     let coinbase_txid = block_proposal.transactions.first().unwrap().txid();
 
     rpc_client.submit_block(block_proposal)?;
@@ -62,16 +60,15 @@ pub fn mine_block(
 pub fn mine_empty_blocks(
     num_blocks: u32,
     rpc_client: &mut dyn RpcClient,
-    activate: bool,
 ) -> Result<(u32, TxId), Box<dyn Error>> {
     if num_blocks == 0 {
         panic!("num_blocks must be greater than 0")
     }
 
-    let (block_height, coinbase_txid) = mine_block(rpc_client, vec![], activate)?;
+    let (block_height, coinbase_txid) = mine_block(rpc_client, vec![])?;
 
     for _ in 1..num_blocks {
-        mine_block(rpc_client, vec![], false)?;
+        mine_block(rpc_client, vec![])?;
     }
 
     Ok((block_height, coinbase_txid))
@@ -473,7 +470,6 @@ pub fn create_finalization_transaction(
 pub fn template_into_proposal(
     block_template: BlockTemplate,
     mut txs: Vec<Transaction>,
-    activate: bool,
 ) -> BlockProposal {
     let coinbase = Transaction::read(
         hex::decode(block_template.coinbase_txn.data)
@@ -519,11 +515,7 @@ pub fn template_into_proposal(
             block_template.previous_block_hash,
         )),
         merkle_root,
-        final_sapling_root: if activate {
-            [0; 32]
-        } else {
-            hash_block_commitments
-        },
+        final_sapling_root: hash_block_commitments,
         time: block_template.cur_time,
         bits: u32::from_str_radix(block_template.bits.as_str(), 16).unwrap(),
         nonce: [2; 32],                 // Currently PoW is switched off in Zebra

--- a/src/components/transactions.rs
+++ b/src/components/transactions.rs
@@ -94,7 +94,7 @@ pub fn create_shield_coinbase_transaction(
     let coinbase_recipient = miner_key.address();
     let pk = miner_key.secret_key().public_key(&Secp256k1::new());
 
-    tx.add_transparent_input(
+    tx.add_transparent_p2pkh_input(
         pk,
         OutPoint::new(coinbase_txid.into(), 0),
         TxOut::new(coinbase_amount, coinbase_recipient.script().into()),
@@ -103,7 +103,7 @@ pub fn create_shield_coinbase_transaction(
     tx.add_orchard_output::<FeeError>(
         Some(wallet.orchard_ovk()),
         recipient,
-        COINBASE_VALUE,
+        Zatoshis::from_u64(COINBASE_VALUE).unwrap(),
         AssetBase::zatoshi(),
         MemoBytes::empty(),
     )
@@ -299,7 +299,7 @@ pub fn create_transfer_transaction(
     tx.add_orchard_output::<FeeError>(
         Some(ovk.clone()),
         recipient,
-        amount,
+        Zatoshis::from_u64(amount).unwrap(),
         asset,
         MemoBytes::empty(),
     )
@@ -310,7 +310,7 @@ pub fn create_transfer_transaction(
         tx.add_orchard_output::<FeeError>(
             Some(ovk),
             sender,
-            change_amount,
+            Zatoshis::from_u64(change_amount).unwrap(),
             asset,
             MemoBytes::empty(),
         )
@@ -367,7 +367,7 @@ pub fn create_burn_transaction(
         tx.add_orchard_output::<FeeError>(
             Some(ovk),
             arsonist,
-            change_amount,
+            Zatoshis::from_u64(change_amount).unwrap(),
             asset,
             MemoBytes::empty(),
         )
@@ -419,7 +419,7 @@ pub fn create_issue_transaction(
     tx.add_orchard_output::<FeeError>(
         Some(wallet.orchard_ovk()),
         dummy_recipient,
-        0,
+        Zatoshis::ZERO,
         AssetBase::zatoshi(),
         MemoBytes::empty(),
     )
@@ -461,7 +461,7 @@ pub fn create_finalization_transaction(
     tx.add_orchard_output::<FeeError>(
         Some(wallet.orchard_ovk()),
         dummy_recipient,
-        0,
+        Zatoshis::ZERO,
         AssetBase::zatoshi(),
         MemoBytes::empty(),
     )
@@ -479,7 +479,7 @@ pub fn template_into_proposal(
         hex::decode(block_template.coinbase_txn.data)
             .unwrap()
             .as_slice(),
-        BranchId::Nu6,
+        BranchId::Nu7,
     )
     .unwrap();
 
@@ -539,7 +539,9 @@ pub fn template_into_proposal(
 }
 
 fn create_tx(target_height: BlockHeight, wallet: &Wallet) -> Builder<'_, RegtestNetwork, ()> {
-    let build_config = BuildConfig::TxV6 {
+    // V6 is the default for the Nu7 branch (which Regtest activates at height 1),
+    // so Standard auto-selects V6 here. No need to call propose_version.
+    let build_config = BuildConfig::Standard {
         sapling_anchor: None,
         orchard_anchor: wallet.orchard_anchor(),
     };

--- a/src/components/wallet.rs
+++ b/src/components/wallet.rs
@@ -310,7 +310,7 @@ impl Wallet {
     }
 
     pub(crate) fn issuance_key(&self) -> IssueAuthKey<ZSASchnorr> {
-        IssueAuthKey::from_zip32_seed(self.seed.as_slice(), constants::testnet::COIN_TYPE, 0)
+        IssueAuthKey::from_zip32_seed(self.seed.as_slice(), constants::regtest::COIN_TYPE, 0)
             .unwrap()
     }
 

--- a/src/components/wallet.rs
+++ b/src/components/wallet.rs
@@ -30,7 +30,7 @@ use zcash_primitives::transaction::components::issuance::write_note;
 use zcash_primitives::transaction::{OrchardBundle, Transaction, TxId};
 use bip0039::Mnemonic;
 use orchard::primitives::OrchardPrimitives;
-use zcash_primitives::zip32::AccountId;
+use zip32::AccountId;
 use zcash_protocol::constants;
 use zcash_protocol::value::ZatBalance;
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,5 @@
 use zcash_primitives::block::BlockHash;
-use zcash_primitives::consensus::BlockHeight;
+use zcash_protocol::consensus::BlockHeight;
 use zcash_primitives::transaction::TxId;
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Upgrade Zebra to `2b036fd6` (a one-line fix on top of `20760d24`) and migrate the tx-tool to `librustzcash 0.26` / `orchard 0.12`. Bumps version to `0.5.0`.

### Changes

**Cargo.toml**
- Direct deps: `orchard 0.11 -> 0.12`, `zcash_primitives 0.25 -> 0.26.1`, `zcash_protocol 0.6.2 -> 0.7.2`, `zcash_proofs 0.25 -> 0.26.1`, `zcash_transparent 0.5 -> 0.6.3`. Added `zip32 = "0.2"` (moved out of `zcash_primitives`).
- `[patch.crates-io]` revs aligned with Zebra: orchard `77d3274c...`, sapling-crypto `59535fb5...`, librustzcash `0ea73754...`. Added `halo2_poseidon` patch.
- Bumped package version to `0.5.0`.

**API migration for librustzcash 0.26 / orchard 0.12**
- `zcash_primitives::consensus` -> `zcash_protocol::consensus` in `src/model.rs`, `src/components/rpc_client/{mock,reqwest}.rs`.
- `zcash_primitives::zip32::AccountId` -> `zip32::AccountId` in `src/components/{miner,wallet}.rs`.
- `Builder::add_transparent_input(pk, op, txout)` -> `add_transparent_p2pkh_input(...)`. The old name now takes a single `TransparentInputInfo`.
- `add_orchard_output` `value: u64` -> `Zatoshis`. 5 call sites wrapped with `Zatoshis::from_u64(...).unwrap()` / `Zatoshis::ZERO`.
- `BuildConfig::TxV6 { ... }` -> `BuildConfig::Standard { ... }`. Auto-selects V6 because Regtest activates Nu7 at height 1 and `TxVersion::suggested_for_branch(Nu7) = V6`.
- `BranchId::Nu6` -> `BranchId::Nu7` for parsing the coinbase out of `getblocktemplate`.

**Block-commitment fix**
- New Zebra dropped the activation-block reserved-zero exception under NU5+, so the `activate: bool` flag was dead-weight. Removed it from `mine` / `mine_block` / `mine_empty_blocks` / `template_into_proposal` and use `hash_block_commitments` unconditionally for `final_sapling_root`.

**CI**
- `.github/workflows/zebra-test-ci.yaml` `ZEBRA_COMMIT` pinned to `2b036fd6`.
